### PR TITLE
Fix huge bottleneck of City Matrix

### DIFF
--- a/PythonAPI/SensorDataCollection/utils.py
+++ b/PythonAPI/SensorDataCollection/utils.py
@@ -3297,7 +3297,8 @@ def update_matrix(
                 entry_highway_road, 
                 exit_highway_road, 
                 right_lane_start_wp, 
-                right_lane_end_wp)
+                right_lane_end_wp,
+                road_lane_ids=road_lane_ids)
             
             if row is None:
                 continue

--- a/PythonAPI/SensorDataCollection/utils.py
+++ b/PythonAPI/SensorDataCollection/utils.py
@@ -160,10 +160,10 @@ def get_all_road_lane_ids(world_map):
         road_lane_ids.add(f"{road_id}_{lane_id}")
     
     # Cache value
-    all_road_lane_ids = road_lane_ids
+    all_road_lane_ids = frozenset(road_lane_ids)
     _active_world_name = world_map.name
 
-    return road_lane_ids
+    return all_road_lane_ids
 
 def distance(p1, p2):
     """Define a function to calculate the distance between two points (carla Location objects).


### PR DESCRIPTION
Hey everyone,

I tracked down the largest bottleneck of the city matrix (when using it on large maps).

The root problem is that that `get_all_road_lane_ids` is an expensive function and used in every step. Problematic is also that it is then also in a loop for each nearby vehicle.

 Its results should be constant as long the map is not changed and we can make use of that.

 - This PR removes the function call in the lower levels and adds all_road_lane_ids as a parameter - theoretically that is not necessary, but I guess could allow some prefiltering to boost the performance further by reducing the ids?
 - Secondly, it implements a simple global cache based on the map's name - and exposes the cache as global variable.
 - Alternatively the function could be wrapped with an least-recently-used cache of size 1 which might be overkill but would look more professionally.  
 - A second commit changes the `all_road_lane_ids` to a frozenset to prevent modification of the cache. 

## Future Work
- The necessary code using [cachetools](https://cachetools.readthedocs.io/en/latest/) has been provided as comments, implementing would need this additional requirement and I was not sure if you would want it / where to put it.
 Note: `functools.lru_cache` would not be sufficient as the hash of Map object changes when a new `map = world.get_map()` is passed down.
- To simplify the code functions now needing the `road_lane_ids` as a required parameter could accept it as optional and fall back to the global cache as a default.